### PR TITLE
Add generative fill tool

### DIFF
--- a/src/constants/tools-config.ts
+++ b/src/constants/tools-config.ts
@@ -32,7 +32,8 @@ export const TOOL_NAMES = {
   GENERATE_TEXT: 'generate_text',
   GENERATE_IMAGE: 'generate_image',
   GENERATE_VIDEO: 'generate_video',
-  INPAINT_IMAGE: 'inpaint_image'
+  INPAINT_IMAGE: 'inpaint_image',
+  GENERATIVE_FILL: 'generative_fill'
 } as const;
 
 export type ToolName = typeof TOOL_NAMES[keyof typeof TOOL_NAMES];
@@ -270,6 +271,14 @@ export const TOOLS_CONFIG: ToolsConfiguration = {
       exportName: "inpaintImageTool",
       ai_enabled: false,
       description: "Inpaint image via AI",
+      category: TOOL_CATEGORIES.PAINTER
+    },
+    {
+      name: TOOL_NAMES.GENERATIVE_FILL,
+      modulePath: "../../src/service-api/api/ai-tool/generative-fill",
+      exportName: "generativeFillTool",
+      ai_enabled: false,
+      description: "Generative fill via AI",
       category: TOOL_CATEGORIES.PAINTER
     }
   ],

--- a/src/react/app/painter/CanvasContainer.tsx
+++ b/src/react/app/painter/CanvasContainer.tsx
@@ -13,6 +13,7 @@ import { useLayersStore } from '../../../zustand/storage/layers-store';
 import { useCurrentLayerIndexStore } from '../../../zustand/store/current-layer-index-store';
 import { usePainterHistoryStore } from '../../../zustand/store/painter-history-store';
 import type { SelectionRect } from '../../../types/ui';
+import { toolRegistry } from '../../../service-api/core/tool-registry';
 
 interface Props {
   pointer: PainterPointer;
@@ -253,6 +254,77 @@ export default function CanvasContainer({
 
       ctx.restore();
       layersStore.updateLayers([...layers]);
+    },
+    generativeFill: async () => {
+      const plugin: any = (window as any).app?.plugins?.getPlugin('obsidian-storyboard');
+      const settings = plugin?.settingsPlugin?.settings;
+      const provider: 'fal' | 'replicate' = settings?.provider || 'fal';
+      const apiKey: string = provider === 'fal' ? settings?.falApiKey : settings?.replicateApiKey;
+      if (!apiKey) {
+        alert('APIキーが設定されていません');
+        return;
+      }
+      const prompt = window.prompt('生成プロンプトを入力してください');
+      if (!prompt) return;
+
+      const width = canvasSize.width;
+      const height = canvasSize.height;
+
+      const baseCanvas = document.createElement('canvas');
+      baseCanvas.width = width;
+      baseCanvas.height = height;
+      const bctx = baseCanvas.getContext('2d');
+      if (!bctx) return;
+      layers.forEach(layer => {
+        if (layer.visible && layer.canvas) {
+          const alpha = layer.opacity !== undefined ? layer.opacity : 1;
+          const blend = layer.blendMode && layer.blendMode !== 'normal' ? layer.blendMode as GlobalCompositeOperation : 'source-over';
+          bctx.globalAlpha = alpha;
+          bctx.globalCompositeOperation = blend;
+          bctx.drawImage(layer.canvas, 0, 0);
+        }
+      });
+      bctx.globalAlpha = 1;
+      bctx.globalCompositeOperation = 'source-over';
+      const imageDataUrl = baseCanvas.toDataURL('image/png');
+
+      const maskCanvas = document.createElement('canvas');
+      maskCanvas.width = width;
+      maskCanvas.height = height;
+      const mctx = maskCanvas.getContext('2d');
+      if (!mctx) return;
+      mctx.fillStyle = 'black';
+      mctx.fillRect(0, 0, width, height);
+      mctx.fillStyle = 'white';
+      if (selectionState.mode === 'rect' && selectionState.selectionRect) {
+        const r = selectionState.selectionRect;
+        mctx.fillRect(r.x, r.y, r.width, r.height);
+      } else if (selectionState.mode === 'lasso' && selectionState.lassoPoints.length > 2) {
+        mctx.beginPath();
+        mctx.moveTo(selectionState.lassoPoints[0].x, selectionState.lassoPoints[0].y);
+        for (let i = 1; i < selectionState.lassoPoints.length; i++) {
+          const p = selectionState.lassoPoints[i];
+          mctx.lineTo(p.x, p.y);
+        }
+        mctx.closePath();
+        mctx.fill();
+      } else if (selectionState.mode === 'magic' && selectionState.magicClipPath) {
+        mctx.fill(selectionState.magicClipPath);
+      } else {
+        mctx.fillRect(0, 0, width, height);
+      }
+      const maskDataUrl = maskCanvas.toDataURL('image/png');
+
+      await toolRegistry.executeTool('generative_fill', {
+        prompt,
+        apiKey,
+        provider,
+        app: (window as any).app,
+        image: imageDataUrl,
+        mask: maskDataUrl,
+        width,
+        height
+      });
     },
     edit: startEdit,
     cancel: cancelSelection

--- a/src/react/app/painter/features/ActionProperties.tsx
+++ b/src/react/app/painter/features/ActionProperties.tsx
@@ -5,6 +5,7 @@ interface ActionPropertiesProps {
   handlers: {
     fill: () => void;
     clear: () => void;
+    generativeFill?: () => void;
     edit?: () => void;
     cancel?: () => void;
   };
@@ -52,13 +53,23 @@ const ActionProperties: FC<ActionPropertiesProps> = ({
         塗りつぶし
       </button>
       
-      <button 
+      <button
         className={buttonClasses}
         onClick={handlers.clear}
         title="クリア"
       >
         クリア
       </button>
+
+      {handlers.generativeFill && (
+        <button
+          className={buttonClasses}
+          onClick={handlers.generativeFill}
+          title="ジェネレーティブ塗りつぶし"
+        >
+          生成塗り
+        </button>
+      )}
       
       {handlers.edit && (
         <button 

--- a/src/service-api/api/ai-tool/generative-fill.ts
+++ b/src/service-api/api/ai-tool/generative-fill.ts
@@ -1,0 +1,108 @@
+import { Tool } from '../../core/tool';
+import { App, TFile } from 'obsidian';
+import { toolRegistry } from '../../core/tool-registry';
+import { useLayersStore } from '../../../zustand/storage/layers-store';
+import { useCurrentLayerIndexStore } from '../../../zustand/store/current-layer-index-store';
+import { usePainterHistoryStore } from '../../../zustand/store/painter-history-store';
+
+namespace Internal {
+  export interface GenerativeFillInput {
+    prompt: string;
+    apiKey: string;
+    provider: 'fal' | 'replicate';
+    app: App;
+    image: string;
+    mask: string;
+    width: number;
+    height: number;
+  }
+
+  export interface GenerativeFillOutput {
+    filePath: string;
+    message: string;
+  }
+
+  export const GENERATIVE_FILL_METADATA = {
+    name: 'generative_fill',
+    description: 'Generatively fill selected area using AI',
+    parameters: {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string', description: 'Prompt text' },
+        apiKey: { type: 'string', description: 'API key' },
+        provider: { type: 'string', description: 'Service provider' },
+        app: { type: 'object', description: 'Obsidian app instance' },
+        image: { type: 'string', description: 'Base64 image' },
+        mask: { type: 'string', description: 'Base64 mask' },
+        width: { type: 'number', description: 'Canvas width' },
+        height: { type: 'number', description: 'Canvas height' }
+      },
+      required: ['prompt', 'apiKey', 'provider', 'app', 'image', 'mask', 'width', 'height']
+    }
+  } as const;
+
+  function loadImage(src: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = src;
+    });
+  }
+
+  export async function executeGenerativeFill(args: GenerativeFillInput): Promise<string> {
+    const { prompt, apiKey, provider, app, image, mask, width, height } = args;
+
+    const inpaintResultStr = await toolRegistry.executeTool('inpaint_image', {
+      prompt,
+      apiKey,
+      provider,
+      app,
+      image,
+      mask
+    });
+    const inpaintResult = JSON.parse(inpaintResultStr) as GenerativeFillOutput;
+
+    const file = app.vault.getAbstractFileByPath(inpaintResult.filePath);
+    if (!file || !(file instanceof TFile)) {
+      throw new Error('生成画像ファイルが見つかりません');
+    }
+    const arrayBuffer = await app.vault.readBinary(file);
+    const blob = new Blob([arrayBuffer]);
+    const url = URL.createObjectURL(blob);
+    const generatedImg = await loadImage(url);
+    URL.revokeObjectURL(url);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('2Dコンテキストの取得に失敗しました');
+
+    ctx.drawImage(generatedImg, 0, 0, width, height);
+
+    const maskImg = await loadImage(mask);
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.drawImage(maskImg, 0, 0, width, height);
+    ctx.globalCompositeOperation = 'source-over';
+
+    const layer = { name: 'Generative Fill', visible: true, opacity: 1, blendMode: 'normal', canvas };
+
+    const layersStore = useLayersStore.getState();
+    const currentLayerIndexStore = useCurrentLayerIndexStore.getState();
+    const historyStore = usePainterHistoryStore.getState();
+
+    historyStore.saveHistory(layersStore.layers, currentLayerIndexStore.currentLayerIndex);
+    layersStore.addLayer(layer);
+
+    return JSON.stringify(inpaintResult);
+  }
+}
+
+export const generativeFillTool: Tool<Internal.GenerativeFillInput> = {
+  name: 'generative_fill',
+  description: 'Generatively fill selected area using AI',
+  parameters: Internal.GENERATIVE_FILL_METADATA.parameters,
+  execute: Internal.executeGenerativeFill
+};
+


### PR DESCRIPTION
## Summary
- implement `generative_fill` service tool to call `inpaint_image` and add result as new layer
- expose new tool in tool registry
- add Generative Fill button in ActionProperties
- hook up button in CanvasContainer to run the service

## Testing
- `npm run typecheck`
- `npm test` *(fails: Could not find tests)*