### PR TITLE
Implement PNG export

### DIFF
--- a/src/app/painter/painter-view.ts
+++ b/src/app/painter/painter-view.ts
@@ -78,7 +78,16 @@ export class PainterView extends FileView {
     editBtn.textContent = t('EDIT_MENU');
 
     const fileBtn = this.addAction('', t('EXPORT_MERGED_IMAGE'), async () => {
-      // TODO: implement export logic
+      if (!this._painterData) return;
+      try {
+        await toolRegistry.executeTool('export_merged_image', {
+          app: this.app,
+          layers: this._painterData.layers,
+          fileName: `${this.file?.basename || 'merged'}.png`
+        });
+      } catch (error) {
+        console.error(error);
+      }
     }) as HTMLElement;
     fileBtn.querySelector('svg')?.remove();
     fileBtn.textContent = t('EXPORT_MERGED_IMAGE');

--- a/src/constants/tools-config.ts
+++ b/src/constants/tools-config.ts
@@ -19,6 +19,7 @@ export const TOOL_NAMES = {
   LOAD_PAINTER_FILE: 'load_painter_file',
   SAVE_PAINTER_FILE: 'save_painter_file',
   GENERATE_THUMBNAIL: 'generate_thumbnail',
+  EXPORT_MERGED_IMAGE: 'export_merged_image',
   UNDO_PAINTER: 'undo_painter',
   REDO_PAINTER: 'redo_painter',
   
@@ -159,6 +160,14 @@ export const TOOLS_CONFIG: ToolsConfiguration = {
       exportName: "savePainterFileTool",
       ai_enabled: false,
       description: "Save PSD file",
+      category: TOOL_CATEGORIES.PAINTER
+    },
+    {
+      name: TOOL_NAMES.EXPORT_MERGED_IMAGE,
+      modulePath: "../../src/service-api/api/painter-tool/export-merged-image",
+      exportName: "exportMergedImageTool",
+      ai_enabled: false,
+      description: "Export merged image as PNG",
       category: TOOL_CATEGORIES.PAINTER
     },
     {

--- a/src/service/api/painter-tool/export-merged-image.ts
+++ b/src/service/api/painter-tool/export-merged-image.ts
@@ -1,0 +1,147 @@
+import { Tool } from '../../core/tool';
+import { App, normalizePath, TFile } from 'obsidian';
+import { Layer } from '../../../types/painter-types';
+
+function ensureCanvas(layer: Layer, width: number, height: number): HTMLCanvasElement {
+  if (typeof HTMLCanvasElement !== 'undefined' && layer.canvas instanceof HTMLCanvasElement) {
+    return layer.canvas;
+  }
+
+  if (typeof document === 'undefined' || typeof HTMLCanvasElement === 'undefined') {
+    return layer.canvas as HTMLCanvasElement;
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = layer.canvas?.width ?? width;
+  canvas.height = layer.canvas?.height ?? height;
+
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) {
+    layer.canvas = canvas;
+    return canvas;
+  }
+
+  const src = layer.canvas as HTMLCanvasElement | { data?: Uint8ClampedArray };
+
+  if (src && 'data' in src && src.data instanceof Uint8ClampedArray) {
+    try {
+      const imageData = new ImageData(src.data, canvas.width, canvas.height);
+      ctx.putImageData(imageData, 0, 0);
+    } catch (error) {
+      ctx.fillStyle = 'white';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+  } else if (src && 'getContext' in src && typeof src.getContext === 'function') {
+    try {
+      ctx.drawImage(src as HTMLCanvasElement, 0, 0);
+    } catch (error) {
+      console.error(error);
+    }
+  } else {
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  layer.canvas = canvas;
+  return canvas;
+}
+
+namespace Internal {
+  export interface ExportMergedImageInput {
+    app: App;
+    layers: Layer[];
+    fileName?: string;
+  }
+
+  export interface ExportMergedImageOutput {
+    filePath: string;
+    message: string;
+  }
+
+  export const EXPORT_MERGED_IMAGE_METADATA = {
+    name: 'export_merged_image',
+    description: 'Export merged image as PNG',
+    parameters: {
+      type: 'object',
+      properties: {
+        app: { type: 'object', description: 'Obsidian app instance' },
+        layers: { type: 'array', description: 'Layer data' },
+        fileName: { type: 'string', description: 'File name', nullable: true }
+      },
+      required: ['app', 'layers']
+    }
+  } as const;
+
+  function dataUrlToUint8Array(dataUrl: string): Uint8Array {
+    const base64 = dataUrl.split(',')[1];
+    return Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+  }
+
+  export async function executeExportMergedImage(args: ExportMergedImageInput): Promise<string> {
+    const { app, layers, fileName } = args;
+    if (!layers || layers.length === 0) throw new Error('no layers');
+
+    const first = ensureCanvas(layers[0], layers[0].canvas?.width || 800, layers[0].canvas?.height || 600);
+    const width = first.width;
+    const height = first.height;
+
+    const composite = document.createElement('canvas');
+    composite.width = width;
+    composite.height = height;
+    const ctx = composite.getContext('2d', { willReadFrequently: true });
+    if (!ctx) throw new Error('2Dコンテキストの取得に失敗しました');
+
+    ctx.clearRect(0, 0, width, height);
+
+    for (const layer of layers) {
+      if (layer.visible && layer.canvas) {
+        try {
+          ctx.globalAlpha = layer.opacity !== undefined ? layer.opacity : 1;
+          const blend = layer.blendMode === 'normal' ? 'source-over' : layer.blendMode;
+          ctx.globalCompositeOperation = blend as GlobalCompositeOperation;
+
+          const canvas = ensureCanvas(layer, width, height);
+          if (canvas instanceof HTMLCanvasElement) {
+            ctx.drawImage(canvas, 0, 0);
+          }
+        } catch (error) {
+          console.error(error);
+        }
+      }
+    }
+
+    const dataUrl = composite.toDataURL('image/png');
+    const bin = dataUrlToUint8Array(dataUrl);
+
+    const activeDir = app.workspace.getActiveFile()?.parent?.path || '';
+    const folder = normalizePath(`${activeDir}/assets`);
+    try {
+      if (!app.vault.getAbstractFileByPath(folder)) await app.vault.createFolder(folder);
+    } catch {
+      /* ignore */
+    }
+    const ext = 'png';
+    let baseName = fileName ?? `merged-${Date.now()}.${ext}`;
+    if (!baseName.endsWith(`.${ext}`)) baseName += `.${ext}`;
+    let fullPath = normalizePath(`${folder}/${baseName}`);
+    let i = 1;
+    while (app.vault.getAbstractFileByPath(fullPath)) {
+      fullPath = `${folder}/${Date.now()}_${i}.${ext}`;
+      i++;
+    }
+    const imageFile: TFile = await app.vault.createBinary(fullPath, bin);
+    const result: ExportMergedImageOutput = {
+      filePath: imageFile.path,
+      message: `画像を書き出しました: ${imageFile.path}`
+    };
+    return JSON.stringify(result);
+  }
+}
+
+export const exportMergedImageTool: Tool<Internal.ExportMergedImageInput> = {
+  name: 'export_merged_image',
+  description: 'Export merged image as PNG',
+  parameters: Internal.EXPORT_MERGED_IMAGE_METADATA.parameters,
+  execute: Internal.executeExportMergedImage
+};
+


### PR DESCRIPTION
## Summary
- add exportMergedImageTool to save flattened layers as PNG
- register export_merged_image in tool config
- hook export action into Painter view

## Testing
- `npm run lint`
- `npm test` *(fails: Could not find '/workspace/obsidian-storyboard/test/**/*.test.js')*
- `npm run typecheck` *(produced type errors)*