### PR TITLE
Add AI storyboard edit support

### DIFF
--- a/src/app/settings/settings-data.ts
+++ b/src/app/settings/settings-data.ts
@@ -1,9 +1,11 @@
 export interface PluginSettings {
   falApiKey: string;
+  styleInstructions: string;
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
   falApiKey: '',
+  styleInstructions: 'コミカルで分かりやすい作風で執筆してください。',
 };
 
 export async function loadSettings(plugin: import('obsidian').Plugin): Promise<PluginSettings> {

--- a/src/app/settings/settings-plugin.ts
+++ b/src/app/settings/settings-plugin.ts
@@ -1,6 +1,7 @@
 import { Plugin } from 'obsidian';
 import { StoryboardSettingTab } from './settings-view';
 import { loadSettings, PluginSettings } from './settings-data';
+import { setPluginSettings } from '../../constants/plugin-settings';
 
 export class SettingsPlugin {
   private plugin: Plugin;
@@ -12,6 +13,11 @@ export class SettingsPlugin {
 
   async initialize(): Promise<void> {
     this.settings = await loadSettings(this.plugin);
+    setPluginSettings(this.settings);
     this.plugin.addSettingTab(new StoryboardSettingTab(this.plugin.app, this.plugin, this.settings));
+  }
+
+  getSettings(): PluginSettings | null {
+    return this.settings;
   }
 }

--- a/src/app/settings/settings-view.ts
+++ b/src/app/settings/settings-view.ts
@@ -29,5 +29,18 @@ export class StoryboardSettingTab extends PluginSettingTab {
             await saveSettings(this.plugin, this.settings);
           })
       );
+
+    new Setting(containerEl)
+      .setName('作風指示')
+      .setDesc('AIが参考にするスタイル指示')
+      .addTextArea(text =>
+        text
+          .setPlaceholder('例: コミカルで分かりやすいトーン')
+          .setValue(this.settings.styleInstructions || '')
+          .onChange(async (value) => {
+            this.settings.styleInstructions = value;
+            await saveSettings(this.plugin, this.settings);
+          })
+      );
   }
 }

--- a/src/constants/plugin-settings.ts
+++ b/src/constants/plugin-settings.ts
@@ -1,0 +1,15 @@
+import type { PluginSettings } from '../app/settings/settings-data';
+
+let settings: PluginSettings | null = null;
+
+export function setPluginSettings(s: PluginSettings): void {
+  settings = s;
+}
+
+export function getPluginSettings(): PluginSettings | null {
+  return settings;
+}
+
+export function getStyleInstructions(): string {
+  return settings?.styleInstructions ?? '';
+}

--- a/src/constants/tools-config.ts
+++ b/src/constants/tools-config.ts
@@ -35,7 +35,10 @@ export const TOOL_NAMES = {
   GENERATE_IMAGE: 'generate_image',
   GENERATE_VIDEO: 'generate_video',
   INPAINT_IMAGE: 'inpaint_image',
-  GENERATIVE_FILL: 'generative_fill'
+  GENERATIVE_FILL: 'generative_fill',
+  ADD_STORYBOARD_ROW: 'add_storyboard_row',
+  ADD_STORYBOARD_ROWS_BULK: 'add_storyboard_rows_bulk',
+  RUN_STORYBOARD_AI_AGENT: 'run_storyboard_ai_agent'
 } as const;
 
 export type ToolName = typeof TOOL_NAMES[keyof typeof TOOL_NAMES];
@@ -79,7 +82,7 @@ export const TOOLS_CONFIG: ToolsConfiguration = {
       name: TOOL_NAMES.LOAD_STORYBOARD_DATA,
       modulePath: "../api/storyboard-tool/load-storyboard-data",
       exportName: "loadStoryboardDataTool",
-      ai_enabled: false,
+      ai_enabled: true,
       description: "Load storyboard data from file",
       category: TOOL_CATEGORIES.STORYBOARD
     },
@@ -298,6 +301,30 @@ export const TOOLS_CONFIG: ToolsConfiguration = {
       ai_enabled: false,
       description: "Generative fill via AI",
       category: TOOL_CATEGORIES.PAINTER
+    },
+    {
+      name: TOOL_NAMES.ADD_STORYBOARD_ROW,
+      modulePath: "../api/storyboard-tool/add-row",
+      exportName: "addStoryboardRowTool",
+      ai_enabled: false,
+      description: "Add one row to storyboard with default text",
+      category: TOOL_CATEGORIES.STORYBOARD
+    },
+    {
+      name: TOOL_NAMES.ADD_STORYBOARD_ROWS_BULK,
+      modulePath: "../api/storyboard-tool/add-rows-bulk",
+      exportName: "addStoryboardRowsBulkTool",
+      ai_enabled: false,
+      description: "Add multiple rows to storyboard at once",
+      category: TOOL_CATEGORIES.STORYBOARD
+    },
+    {
+      name: TOOL_NAMES.RUN_STORYBOARD_AI_AGENT,
+      modulePath: "../api/storyboard-tool/ai-storyboard-agent",
+      exportName: "runStoryboardAiAgentTool",
+      ai_enabled: false,
+      description: "Run AI agent to edit storyboard",
+      category: TOOL_CATEGORIES.STORYBOARD
     }
   ],
   config: {

--- a/src/hooks/useStoryboardData.ts
+++ b/src/hooks/useStoryboardData.ts
@@ -55,18 +55,6 @@ export default function useStoryboardData(
     [updateData]
   );
 
-  const addRow = useCallback(
-    (chapterIndex: number) => {
-      const newFrame = createEmptyFrame();
-      updateData(prev => {
-        const chapters = prev.chapters.map((ch, cIdx) =>
-          cIdx === chapterIndex ? { ...ch, frames: [...ch.frames, newFrame] } : ch,
-        );
-        return { ...prev, chapters };
-      });
-    },
-    [updateData]
-  );
 
   const deleteRow = useCallback(
     (chapterIndex: number, rowIndex: number) => {
@@ -199,7 +187,6 @@ export default function useStoryboardData(
     storyboard,
     setStoryboard,
     handleCellChange,
-    addRow,
     deleteRow,
     moveRowUp,
     moveRowDown,
@@ -210,4 +197,4 @@ export default function useStoryboardData(
     uniqueSpeakers,
     allCharacters,
   };
-} 
+}

--- a/src/hooks/useStoryboardPageData.ts
+++ b/src/hooks/useStoryboardPageData.ts
@@ -30,6 +30,29 @@ export default function useStoryboardPageData(app: App, file: TFile | null) {
   );
 
   const hookData = useStoryboardData(initialData, handleDataChange);
+  const { setStoryboard, ...restHookData } = hookData;
+
+  const addRow = useCallback(
+    async (chapterIndex: number, initialText = '') => {
+      if (!file) return;
+      try {
+        await toolRegistry.executeTool('add_storyboard_row', {
+          app,
+          file,
+          chapterIndex,
+          initialText,
+        });
+        const result = await toolRegistry.executeTool('load_storyboard_data', {
+          app,
+          file,
+        });
+        setStoryboard(JSON.parse(result));
+      } catch (error) {
+        console.error(error);
+      }
+    },
+    [app, file, setStoryboard]
+  );
 
   useEffect(() => {
     const loadData = async () => {
@@ -51,5 +74,5 @@ export default function useStoryboardPageData(app: App, file: TFile | null) {
     loadData();
   }, [app, file]);
 
-  return { isLoading, handleDataChange, ...hookData };
+  return { isLoading, handleDataChange, addRow, ...restHookData };
 }

--- a/src/service/api/storyboard-tool/add-row.ts
+++ b/src/service/api/storyboard-tool/add-row.ts
@@ -1,0 +1,59 @@
+import { Tool } from '../../core/tool';
+import { App, TFile } from 'obsidian';
+import { TOOL_NAMES } from '../../../constants/tools-config';
+import { toolRegistry } from '../../core/tool-registry';
+import { StoryboardData, StoryboardFrame } from '../../../types/storyboard';
+
+namespace Internal {
+  export interface AddStoryboardRowInput {
+    app: App;
+    file: TFile;
+    chapterIndex: number;
+    initialText?: string;
+  }
+
+  export interface AddStoryboardRowOutput {
+    message: string;
+  }
+
+  export async function executeAddStoryboardRow(args: AddStoryboardRowInput): Promise<string> {
+    const { app, file, chapterIndex, initialText = '' } = args;
+    const dataStr = await toolRegistry.executeTool<string, string>(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
+    const data = JSON.parse(dataStr) as StoryboardData;
+    const frame: StoryboardFrame = {
+      dialogues: initialText,
+      speaker: '',
+      imageUrl: '',
+      imagePrompt: '',
+      prompt: '',
+      endTime: '',
+    };
+    if (!data.chapters[chapterIndex]) {
+      data.chapters[chapterIndex] = { bgmPrompt: '', frames: [] };
+    }
+    data.chapters[chapterIndex].frames.push(frame);
+    await toolRegistry.executeTool(TOOL_NAMES.SAVE_STORYBOARD_DATA, {
+      app,
+      file,
+      data: JSON.stringify(data)
+    });
+    const out: AddStoryboardRowOutput = { message: '行を追加しました' };
+    return JSON.stringify(out);
+  }
+}
+
+export const addStoryboardRowTool: Tool<Internal.AddStoryboardRowInput> = {
+  name: TOOL_NAMES.ADD_STORYBOARD_ROW,
+  description: 'Add one row to storyboard with default text',
+  parameters: {
+    type: 'object',
+    properties: {
+      app: { type: 'object', description: 'Obsidian app instance' },
+      file: { type: 'object', description: 'Target storyboard file' },
+      chapterIndex: { type: 'number', description: 'Chapter index' },
+      initialText: { type: 'string', description: 'Initial dialogue text', nullable: true }
+    },
+    required: ['app', 'file', 'chapterIndex']
+  },
+  execute: Internal.executeAddStoryboardRow
+};

--- a/src/service/api/storyboard-tool/add-rows-bulk.ts
+++ b/src/service/api/storyboard-tool/add-rows-bulk.ts
@@ -1,0 +1,51 @@
+import { Tool } from '../../core/tool';
+import { App, TFile } from 'obsidian';
+import { TOOL_NAMES } from '../../../constants/tools-config';
+import { toolRegistry } from '../../core/tool-registry';
+import { StoryboardData, StoryboardFrame } from '../../../types/storyboard';
+
+namespace Internal {
+  export interface AddStoryboardRowsBulkInput {
+    app: App;
+    file: TFile;
+    chapterIndex: number;
+    texts: string[];
+  }
+
+  export interface AddStoryboardRowsBulkOutput {
+    added: number;
+    message: string;
+  }
+
+  export async function executeAddStoryboardRowsBulk(args: AddStoryboardRowsBulkInput): Promise<string> {
+    const { app, file, chapterIndex, texts } = args;
+    const dataStr = await toolRegistry.executeTool<string, string>(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
+    const data = JSON.parse(dataStr) as StoryboardData;
+    if (!data.chapters[chapterIndex]) {
+      data.chapters[chapterIndex] = { bgmPrompt: '', frames: [] };
+    }
+    for (const t of texts) {
+      const frame: StoryboardFrame = { dialogues: t, speaker: '', imageUrl: '', imagePrompt: '', prompt: '', endTime: '' };
+      data.chapters[chapterIndex].frames.push(frame);
+    }
+    await toolRegistry.executeTool(TOOL_NAMES.SAVE_STORYBOARD_DATA, { app, file, data: JSON.stringify(data) });
+    const out: AddStoryboardRowsBulkOutput = { added: texts.length, message: '行を追加しました' };
+    return JSON.stringify(out);
+  }
+}
+
+export const addStoryboardRowsBulkTool: Tool<Internal.AddStoryboardRowsBulkInput> = {
+  name: TOOL_NAMES.ADD_STORYBOARD_ROWS_BULK,
+  description: 'Add multiple rows to storyboard at once',
+  parameters: {
+    type: 'object',
+    properties: {
+      app: { type: 'object', description: 'Obsidian app instance' },
+      file: { type: 'object', description: 'Target storyboard file' },
+      chapterIndex: { type: 'number', description: 'Chapter index' },
+      texts: { type: 'array', description: 'List of dialogue texts', items: { type: 'string' } }
+    },
+    required: ['app', 'file', 'chapterIndex', 'texts']
+  },
+  execute: Internal.executeAddStoryboardRowsBulk
+};

--- a/src/service/api/storyboard-tool/ai-storyboard-agent.ts
+++ b/src/service/api/storyboard-tool/ai-storyboard-agent.ts
@@ -1,0 +1,64 @@
+import { Tool } from '../../core/tool';
+import { App, TFile } from 'obsidian';
+import { TOOL_NAMES } from '../../../constants/tools-config';
+import { toolRegistry } from '../../core/tool-registry';
+import { getStyleInstructions, getPluginSettings } from '../../../constants/plugin-settings';
+
+namespace Internal {
+  export interface RunStoryboardAiAgentInput {
+    app: App;
+    file: TFile;
+    prompt: string;
+    chapterIndex: number;
+  }
+
+  export interface RunStoryboardAiAgentOutput {
+    added: number;
+    message: string;
+  }
+
+  export async function executeRunStoryboardAiAgent(args: RunStoryboardAiAgentInput): Promise<string> {
+    const { app, file, prompt, chapterIndex } = args;
+    const dataStr = await toolRegistry.executeTool<string, string>(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
+    const settings = getPluginSettings();
+    const instructions = getStyleInstructions();
+    const apiKey = settings?.falApiKey ?? '';
+    const message = `${prompt}\n`;
+    const gen = await toolRegistry.executeTool(TOOL_NAMES.GENERATE_TEXT, {
+      apiKey,
+      provider: 'fal',
+      instructions,
+      message,
+      history: []
+    });
+    const { text } = JSON.parse(gen) as { text: string };
+    if (!text) {
+      return JSON.stringify({ added: 0, message: 'AIから結果が得られませんでした' });
+    }
+    const lines = text.split(/\n+/).map(l => l.trim()).filter(l => l);
+    await toolRegistry.executeTool(TOOL_NAMES.ADD_STORYBOARD_ROWS_BULK, {
+      app,
+      file,
+      chapterIndex,
+      texts: lines
+    });
+    const out: RunStoryboardAiAgentOutput = { added: lines.length, message: 'AIによる行追加完了' };
+    return JSON.stringify(out);
+  }
+}
+
+export const runStoryboardAiAgentTool: Tool<Internal.RunStoryboardAiAgentInput> = {
+  name: TOOL_NAMES.RUN_STORYBOARD_AI_AGENT,
+  description: 'Run AI agent to edit storyboard',
+  parameters: {
+    type: 'object',
+    properties: {
+      app: { type: 'object', description: 'Obsidian app instance' },
+      file: { type: 'object', description: 'Target storyboard file' },
+      prompt: { type: 'string', description: 'User prompt for AI' },
+      chapterIndex: { type: 'number', description: 'Target chapter index' }
+    },
+    required: ['app', 'file', 'prompt', 'chapterIndex']
+  },
+  execute: Internal.executeRunStoryboardAiAgent
+};

--- a/src/service/api/storyboard-tool/index.ts
+++ b/src/service/api/storyboard-tool/index.ts
@@ -4,3 +4,6 @@ export { toggleStoryboardViewTool } from './toggle-storyboard-view';
 export { loadStoryboardDataTool } from './load-storyboard-data';
 export { saveStoryboardDataTool } from './save-storyboard-data';
 export { exportStoryboardJsonTool } from './export-storyboard-json';
+export { addStoryboardRowTool } from './add-row';
+export { addStoryboardRowsBulkTool } from './add-rows-bulk';
+export { runStoryboardAiAgentTool } from './ai-storyboard-agent';

--- a/src/service/core/all-tools.ts
+++ b/src/service/core/all-tools.ts
@@ -16,7 +16,10 @@ import {
   toggleStoryboardViewTool,
   loadStoryboardDataTool,
   saveStoryboardDataTool,
-  exportStoryboardJsonTool
+  exportStoryboardJsonTool,
+  addStoryboardRowTool,
+  addStoryboardRowsBulkTool,
+  runStoryboardAiAgentTool
 } from '../api/storyboard-tool';
 
 import {
@@ -54,6 +57,9 @@ export const ALL_TOOLS: Tool<any, any>[] = [
   loadStoryboardDataTool,
   saveStoryboardDataTool,
   exportStoryboardJsonTool,
+  addStoryboardRowTool,
+  addStoryboardRowsBulkTool,
+  runStoryboardAiAgentTool,
   createUsdFileTool,
   loadUsdFileTool,
   saveUsdFileTool,


### PR DESCRIPTION
## Summary
- add global accessors for plugin settings
- support style instructions setting
- register new storyboard editing tools
- implement bulk row addition and AI agent
- unify row addition to use the new tool

## Testing
- `npm test` *(fails: Could not find test files)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683ade83c5d0832bbdd9e5eeca874997