### PR TITLE
Update default model for fal.ai

### DIFF
--- a/src/service/api/agent-tool/init-agent.ts
+++ b/src/service/api/agent-tool/init-agent.ts
@@ -29,7 +29,7 @@ export function initAgent(options: AgentOptions): Agent {
   return {
     apiKey: options.apiKey,
     instructions: options.instructions ?? 'You are a helpful assistant.',
-    model: options.model ?? 'gpt-4o',
+    model: options.model ?? 'openai/gpt-4o',
     tools: options.tools ?? [],
     history: []
   };

--- a/src/service/api/storyboard-tool/ai-storyboard-agent.ts
+++ b/src/service/api/storyboard-tool/ai-storyboard-agent.ts
@@ -27,6 +27,7 @@ namespace Internal {
     const gen = await toolRegistry.executeTool(TOOL_NAMES.GENERATE_TEXT, {
       apiKey,
       provider: 'fal',
+      model: 'openai/gpt-4o',
       instructions,
       message,
       history: []


### PR DESCRIPTION
## Summary
- use `openai/gpt-4o` as the default model when initializing an agent
- pass the same model explicitly when running the storyboard AI agent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683aefe1d6f4832ba2a610a06dabf4b0