### PR TITLE
Enable ChatBox AI commands

### DIFF
--- a/src/components/right-sidebar/Page.tsx
+++ b/src/components/right-sidebar/Page.tsx
@@ -177,7 +177,7 @@ export default function RightSidebarReactView({ view, app }: RightSidebarReactVi
         app={app || ({} as App)}
       />
       {layers && layers.length > 0 && <LayerControls />}
-      <ChatBox />
+      <ChatBox app={app || ({} as App)} />
     </div>
   );
 }

--- a/src/service/api/ai-tool/generate-text.ts
+++ b/src/service/api/ai-tool/generate-text.ts
@@ -1,6 +1,7 @@
 import { Tool } from '../../core/tool';
 import { initAgent, AgentOptions, ChatMessage, Attachment } from '../agent-tool/init-agent';
 import { runAgent } from '../agent-tool/run-agent';
+import { toolRegistry } from '../../core/tool-registry';
 
 namespace Internal {
   export interface GenerateTextInput extends AgentOptions {
@@ -34,8 +35,9 @@ namespace Internal {
   } as const;
 
   export async function executeGenerateText(args: GenerateTextInput): Promise<string> {
-    const { message, history = [], attachments = [], ...agentOpts } = args;
-    const agent = initAgent(agentOpts);
+    const { message, history = [], attachments = [], tools, ...agentOpts } = args;
+    const agentTools = tools ?? toolRegistry.getAiEnabledTools();
+    const agent = initAgent({ ...agentOpts, tools: agentTools });
     agent.history = history;
     const result = await runAgent(agent, message, attachments);
     const out: GenerateTextOutput = { text: result.finalOutput, history: result.history };


### PR DESCRIPTION
## Summary
- use ai-enabled tools by default when generating text
- add ChatBox commands to run storyboard AI agent and edit painter layers
- pass app instance to ChatBox for tool execution

## Testing
- `npm test` *(fails: Could not find tests)*
- `npm run typecheck`
- `npm run lint` *(fails: 2 errors in CanvasContainer.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_683b1612f948832b8d1618723f09498f