### PR TITLE
fix transform overlay position with zoom

### DIFF
--- a/src/components/painter/canvas/CanvasContainer.tsx
+++ b/src/components/painter/canvas/CanvasContainer.tsx
@@ -517,6 +517,7 @@ export default function CanvasContainer({
             rect={editRect}
             layers={layers}
             currentLayerIndex={currentLayerIndex}
+            containerRef={containerRef}
             onFinish={finishEdit}
           />
         )}

--- a/typecheck-results.txt
+++ b/typecheck-results.txt
@@ -1,3 +1,4 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 src/app/painter/painter-view.ts(81,17): error TS2339: Property '_painterData' does not exist on type 'PainterView'.
 src/app/painter/painter-view.ts(85,24): error TS2339: Property '_painterData' does not exist on type 'PainterView'.
 src/components/painter/tools/ColorProperties.tsx(2,33): error TS2307: Cannot find module '../../../../utils/storage/painter-layout-store' or its corresponding type declarations.


### PR DESCRIPTION
## Summary
- account for canvas zoom when positioning TransformEditOverlay

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683b1e0d3c84832bb7c31527367e42a1