### PR TITLE
Fix painter layout path import

### DIFF
--- a/src/components/painter/tools/ColorProperties.tsx
+++ b/src/components/painter/tools/ColorProperties.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { LayoutDirection } from '../../../../utils/storage/painter-layout-store';
+import { LayoutDirection } from '../../../storage/painter-layout-store';
 import ColorWheel from '../../utils/color/ColorWheel';
 import { hexToHsl, hslToHex } from '../../utils/color/color';
 


### PR DESCRIPTION
## Summary
- fix ColorProperties import path for LayoutDirection

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683b1fea2174832b84b9ac967d250681