### PR TITLE
Add PainterData property to PainterView

### DIFF
--- a/src/app/painter/painter-view.ts
+++ b/src/app/painter/painter-view.ts
@@ -3,10 +3,12 @@ import { Root } from 'react-dom/client';
 import { t } from '../../constants/obsidian-i18n';
 import { toolRegistry } from '../../service/core/tool-registry';
 import { setDisplayText } from '../utils/view-title-updater';
+import type { PainterData } from 'src/types/painter-types';
 
 export class PainterView extends FileView {
   public reactRoot: Root | null = null;
   public renderReact: () => void;
+  public _painterData?: PainterData;
   private actionsAdded = false;
 
   constructor(leaf: WorkspaceLeaf, renderReact: () => void) {

--- a/typecheck-results.txt
+++ b/typecheck-results.txt
@@ -1,5 +1,4 @@
-src/app/painter/painter-view.ts(81,17): error TS2339: Property '_painterData' does not exist on type 'PainterView'.
-src/app/painter/painter-view.ts(85,24): error TS2339: Property '_painterData' does not exist on type 'PainterView'.
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 src/components/painter/tools/ColorProperties.tsx(2,33): error TS2307: Cannot find module '../../../../utils/storage/painter-layout-store' or its corresponding type declarations.
 src/components/storyboard/Page.tsx(134,11): error TS2322: Type '{ imageUrl: string | undefined; imagePrompt: string | undefined; onImageUrlChange: (newUrl: string | null) => void; onImagePromptChange: (newImagePrompt: string) => void; app: App; ... 4 more ...; refCallback: (el: HTMLTextAreaElement | null) => void; }' is not assignable to type 'IntrinsicAttributes & ImageInputCellProps'.
   Property 'generateThumbnail' does not exist on type 'IntrinsicAttributes & ImageInputCellProps'.


### PR DESCRIPTION
## Summary
- expose `_painterData` on `PainterView` class
- import `PainterData` type in `painter-view.ts`
- update typecheck results

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683b1feb8374832b8148a375bac9e722