### PR TITLE
Add Layer type usage in layers store

### DIFF
--- a/src/storage/adaptive-debouncer.ts
+++ b/src/storage/adaptive-debouncer.ts
@@ -1,11 +1,11 @@
 // シンプルなデバウンス処理
-export class AdaptiveDebouncer {
+export class AdaptiveDebouncer<T extends (...args: any[]) => any> {
   private timeout: NodeJS.Timeout | null = null;
   private saveHistory: number[] = []; // 保存実行のタイムスタンプ履歴
 
-  constructor(private func: Function) {}
+  constructor(private func: T) {}
 
-  execute(...args: unknown[]) {
+  execute(...args: Parameters<T>) {
     const now = Date.now();
 
     // 過去1分間の保存履歴をクリーンアップ

--- a/src/storage/layers-store.ts
+++ b/src/storage/layers-store.ts
@@ -4,14 +4,15 @@ import { TFile } from "obsidian";
 import { toolRegistry } from "src/service/core/tool-registry";
 import { subscribeWithSelector } from "zustand/middleware";
 import { AdaptiveDebouncer } from "./adaptive-debouncer";
+import type { Layer } from 'src/types/painter-types';
 
 
 interface LayersState {
-  layers: import('src/types/painter-types').Layer[];
+  layers: Layer[];
   currentPsdFile: TFile | null;
-  updateLayers: (layers: import('src/types/painter-types').Layer[]) => void;
-  initializeLayers: (layers: import('src/types/painter-types').Layer[]) => void;
-  addLayer: (layer: import('src/types/painter-types').Layer) => void;
+  updateLayers: (layers: Layer[]) => void;
+  initializeLayers: (layers: Layer[]) => void;
+  addLayer: (layer: Layer) => void;
   removeLayer: (index: number) => void;
   toggleLayerVisibility: (index: number) => void;
   setLayerOpacity: (index: number, opacity: number) => void;


### PR DESCRIPTION
## Summary
- `Layer` 型の import を追加
- `AdaptiveDebouncer` をジェネリック化して型安全に
- `layers-store` 内で `Layer` 型を直接利用

## Testing
- `npm run typecheck` を実行
  - 既存の他ファイル由来のエラーは残るが、今回の変更による新たなエラーは無し

------
https://chatgpt.com/codex/tasks/task_e_683b1fee2948832babc69caa0af7c581