### PR TITLE
Remove generics from executeTool calls

### DIFF
--- a/src/service/api/storyboard-tool/add-row.ts
+++ b/src/service/api/storyboard-tool/add-row.ts
@@ -18,7 +18,7 @@ namespace Internal {
 
   export async function executeAddStoryboardRow(args: AddStoryboardRowInput): Promise<string> {
     const { app, file, chapterIndex, initialText = '' } = args;
-    const dataStr = await toolRegistry.executeTool<string, string>(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
+    const dataStr = await toolRegistry.executeTool(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
     const data = JSON.parse(dataStr) as StoryboardData;
     const frame: StoryboardFrame = {
       dialogues: initialText,

--- a/src/service/api/storyboard-tool/add-rows-bulk.ts
+++ b/src/service/api/storyboard-tool/add-rows-bulk.ts
@@ -19,7 +19,7 @@ namespace Internal {
 
   export async function executeAddStoryboardRowsBulk(args: AddStoryboardRowsBulkInput): Promise<string> {
     const { app, file, chapterIndex, texts } = args;
-    const dataStr = await toolRegistry.executeTool<string, string>(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
+    const dataStr = await toolRegistry.executeTool(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
     const data = JSON.parse(dataStr) as StoryboardData;
     if (!data.chapters[chapterIndex]) {
       data.chapters[chapterIndex] = { bgmPrompt: '', frames: [] };

--- a/src/service/api/storyboard-tool/ai-storyboard-agent.ts
+++ b/src/service/api/storyboard-tool/ai-storyboard-agent.ts
@@ -19,7 +19,7 @@ namespace Internal {
 
   export async function executeRunStoryboardAiAgent(args: RunStoryboardAiAgentInput): Promise<string> {
     const { app, file, prompt, chapterIndex } = args;
-    const dataStr = await toolRegistry.executeTool<string, string>(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
+    const dataStr = await toolRegistry.executeTool(TOOL_NAMES.LOAD_STORYBOARD_DATA, { app, file });
     const settings = getPluginSettings();
     const instructions = getStyleInstructions();
     const apiKey = settings?.falApiKey ?? '';


### PR DESCRIPTION
## Summary
- remove redundant generic parameters from `executeTool` calls
- run typecheck to ensure storyboard tool files produce no errors

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683b1feefe84832baf4076379f552229